### PR TITLE
Remove osxkeychain credential helper from .gitconfig

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -56,6 +56,3 @@
     tool = default-difftool
 [difftool "default-difftool"]
     cmd = code --wait --diff $LOCAL $REMOTE
-[credential]
-	# Use macOS Keychain to store HTTP passwords.
-	helper = osxkeychain	


### PR DESCRIPTION
Fixes #63